### PR TITLE
Update splunk_sdk.py - Bug Fix for Multiple Credentials in Splunk Cred Store

### DIFF
--- a/twistlock/bin/utils/splunk_sdk.py
+++ b/twistlock/bin/utils/splunk_sdk.py
@@ -32,13 +32,18 @@ def get_credentials(session_key):
 
 
 def get_config_stanza(realm, session_key):
+    logger.info("Realm: %s", realm)
+
     try:
         entities = entity.getEntities(
             ["configs", "conf-twistlock", realm], namespace="twistlock",
             owner="nobody", sessionKey=session_key)
+        logger.info("Entities: %s", entities)
         conf_values = entities[realm]
     except Exception as e:
         logger.error("Failed getting configuration from Splunk: %r", e)
+        stanza = "error"
+        return stanza
 
     stanza = {
         "console_addr": conf_values["console_addr"],
@@ -55,9 +60,16 @@ def get_config_stanza(realm, session_key):
 
 def generate_configs(session_key):
     configs = []
+    err = "error"
     credentials = get_credentials(session_key)
+    """logger.info("Creds: %s", credentials)"""
+
     for credential in credentials:
+        logger.info("Realm1: %s", credential["realm"])
         stanza = get_config_stanza(credential["realm"], session_key)
+        if (stanza is err):
+            continue
         stanza.update(credential)
         configs.append(stanza)
+
     return configs


### PR DESCRIPTION
## Description

splunk_skd.py doesn't handle errors related to the "generate_config" function or log well, added a few tweaks to assist with the and troubleshooting.

## Motivation and Context

Splunk Environments with multiple credential stores / TA-s using the credential store will break the "generate_config" function. Loop required the addition of a "continue" statement to work using multiple entries.

## How Has This Been Tested?

This correction has been running in a production environment for ~ 8 months with no issues.

## Screenshots (if appropriate)
N/A

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X ] I have added tests to cover my changes if appropriate.
- [X ] All new and existing tests passed.
